### PR TITLE
Updated selectors to work with these changes: http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -90,7 +90,7 @@ kbd {
 
 // input
 
-atom-text-editor[mini], atom-text-editor[mini]::shadow {
+atom-text-editor[mini], atom-text-editor[mini].editor {
   transition: all @transition-time ease;
   color: @text-color-highlight;
   background-color: @input-background-color;
@@ -116,7 +116,7 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused.editor {
   background-color: @input-background-color-active;
 
   &:hover {

--- a/styles/components/editor.less
+++ b/styles/components/editor.less
@@ -2,7 +2,7 @@
 @import "ui-mixins.less";
 @import "octicon-mixins";
 
-atom-text-editor, atom-text-editor::shadow, :host {
+atom-text-editor, atom-text-editor.editor, :host {
   .scroll-view {
     padding: 0px;
   }

--- a/styles/components/overlays.less
+++ b/styles/components/overlays.less
@@ -25,7 +25,7 @@ atom-panel.modal, .overlay {
     .text(light);
   }
 
-  atom-text-editor[mini], atom-text-editor.mini, atom-text-editor.mini::shadow, atom-text-editor[mini]::shadow {
+  atom-text-editor[mini], atom-text-editor.mini, atom-text-editor.mini.editor, atom-text-editor[mini].editor {
     .text(heading);
     color: @text-color-highlight;
     font-size: 24px;

--- a/styles/packages/package-linter.less
+++ b/styles/packages/package-linter.less
@@ -32,7 +32,7 @@ linter-panel:empty {
   display: none;
 }
 
-atom-text-editor, atom-text-editor::shadow, :host {
+atom-text-editor, atom-text-editor.editor, :host {
   .gutter {
     .linter-gutter {
       border-radius: 100%;

--- a/styles/packages/package-minimap.less
+++ b/styles/packages/package-minimap.less
@@ -1,7 +1,7 @@
 @import "ui-variables.less";
 @import "ui-mixins.less";
 
-atom-text-editor::shadow atom-text-editor-minimap::shadow .minimap-visible-area,
+atom-text-editor.editor atom-text-editor-minimap::shadow .minimap-visible-area,
 atom-text-editor atom-text-editor-minimap::shadow .minimap-visible-area,
 html atom-text-editor-minimap::shadow .minimap-visible-area {
   opacity: 1.0;


### PR DESCRIPTION
	modified:   styles/atom.less
	modified:   styles/components/editor.less
	modified:   styles/components/overlays.less
	modified:   styles/packages/package-linter.less
	modified:   styles/packages/package-minimap.less